### PR TITLE
more stable server URL

### DIFF
--- a/crawlingathome.py
+++ b/crawlingathome.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
     import crawlingathome_client as cah
 
     YOUR_NICKNAME_FOR_THE_LEADERBOARD = "Wiki_live_test"
-    CRAWLINGATHOME_SERVER_URL = "http://crawlingathome.duckdns.org/"
+    CRAWLINGATHOME_SERVER_URL = "https://api.gagepiracy.com:4483/"
 
     client = cah.init(
         url=CRAWLINGATHOME_SERVER_URL, nickname=YOUR_NICKNAME_FOR_THE_LEADERBOARD


### PR DESCRIPTION
As the servers just switched, we are trying to move away from DuckDNS's DDNS service because of the fact it may have stability issues as it is a free service. @DefinatelyNotSam on discord has connected us up with a much more powerful server on their hardware, as well as a much more reliable DNS.